### PR TITLE
fix: pass inputs args to packages.nix

### DIFF
--- a/container.nix
+++ b/container.nix
@@ -15,7 +15,7 @@ in {
     shellInit = "export DISPLAY=${get-host-ip}:0";
   };
 
-  environment.systemPackages = builtins.concatLists (builtins.attrValues (import ./packages.nix pkgs));
+  environment.systemPackages = builtins.concatLists (builtins.attrValues (import ./packages.nix { inherit pkgs inputs; }));
 
   networking = {
     nat = {

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
     nixosConfigurations = genSystems (system:
       nixpkgs.lib.nixosSystem {
         inherit system;
+        specialArgs = { inherit inputs; };
         modules = [./container.nix];
       });
 


### PR DESCRIPTION
Fix container creation error when "inputs" argument wasn't properly passed from flake.nix to package.nix

![image](https://user-images.githubusercontent.com/8515861/184662134-e33af865-2c07-42c0-a074-a60938c61a7a.png)
